### PR TITLE
Added the target_status field to the bid obj

### DIFF
--- a/definition/Bid.ts
+++ b/definition/Bid.ts
@@ -39,6 +39,7 @@ type Bid = {
     priceDetails?: string[],
     bid_score?: number,
     bid_score_process?: string,
+    target_status?: Array<'approved'>,
 };
 
 export default Bid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rtech-struct",
-  "version": "2.31.0",
+  "version": "2.32.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rtech-struct",
-      "version": "2.31.0",
+      "version": "2.32.1",
       "license": "ISC",
       "dependencies": {
         "currency-iso": "^1.0.4",

--- a/structures/bid.js
+++ b/structures/bid.js
@@ -62,7 +62,8 @@ exports.bid = function (config = null, auction = null) {
             deDateUtc: s.optional(dateUtc()),
             deDateRangeUtc: s.optional(dateUtc()),
             bid_score: s.optional(s.number()),
-            bid_score_process: s.optional(s.size(s.string(), 2, 254))
+            bid_score_process: s.optional(s.size(s.string(), 2, 254)),
+            target_status: s.optional(s.array(s.enums(['approved'])))
         }), {
             id: require('uuid').v4(),
             key: auction && auction.key ? auction.key : "",

--- a/test/structures/bid.test.js
+++ b/test/structures/bid.test.js
@@ -305,5 +305,26 @@ describe('Bid object structure', () => {
     expect(entity).toBeUndefined()
     expect(error).toBeDefined()
     expect(error).toHaveProperty('path', ['bid_score_process'])
+  })  
+
+  test('Success: Bid structure with approved as target_status', () => {
+    let payload = JSON.parse(JSON.stringify(Bids[0]));
+    payload.target_status = ['approved'];
+    const [err0, val0] = s.validate(payload, BidStruct, {
+      coerce: true, mask: true
+    })
+    expect(err0).toBeUndefined()
+    expect(val0).toBeDefined()
+    expect(val0.target_status).toStrictEqual(['approved'])
+  })
+  
+  test('Failed: Bid structure with invalid target_status value', () => {
+      let payload = JSON.parse(JSON.stringify(Bids[0]));
+      payload.target_status = ['SOME_WRONG_VALUE'];
+      const [err0, val0] = s.validate(payload, BidStruct, {
+          coerce: true, mask: true
+      })
+      expect(err0).toBeDefined()
+      expect(val0).toBeUndefined()
   })
 })


### PR DESCRIPTION
Card: https://sprints.zoho.eu/team/redspherproduct#itemdetails/P20/I702

Solr update schema:

- bid
`curl -X POST -H 'Content-type:application/json' --user 'solr:yoctu' --data '{ "add-field": { "name": "target_status", "type": "strings", "uninvertible": false, "multiValued": true, "indexed": true, "stored": true, "required": false  } }' 'http://solr.test.yoctu.solutions:8983/api/collections/bid/schema'`

- bid-archive
`curl -X POST -H 'Content-type:application/json' --user 'solr:yoctu' --data '{ "add-field": { "name": "target_status", "type": "strings", "uninvertible": false, "multiValued": true, "indexed": true, "stored": true, "required": false  } }' 'http://solr.test.yoctu.solutions:8983/api/collections/bid-archive/schema'`