### PR TITLE
fix/spql145_sourceComment_size

### DIFF
--- a/structures/bid.js
+++ b/structures/bid.js
@@ -31,7 +31,7 @@ exports.bid = function (config = null, auction = null) {
             options: s.optional(s.array(s.enums(['ALLOW_EXTEND_ON_EXPIRED']))),
             creator: s.size(s.string(), 2, 32),
             source: s.size(s.array(s.size(s.string(), 2, 64)), 0, 5),
-            sourceComment: s.optional(s.size(s.array(s.size(s.string(), 2, 256)), 0, 8)),
+            sourceComment: s.optional(s.size(s.array(s.size(s.string(), 2, 512)), 0, 8)),
             target: s.size(s.array(s.size(s.string(), 2, 64)), 0, 5),
             targetComment: s.optional(s.size(s.array(s.size(s.string(), 2, 256)), 0, 8)),
             targetRating: s.optional(s.size(s.number(), 0, 5)),


### PR DESCRIPTION
# Fix: [l145](https://sprints.zoho.eu/team/redspherproduct#itemdetails/P37/I145)

## Changes
- Update source comment limit size from 256 to 512