### PR TITLE
[address-book] No ID on input

### DIFF
--- a/definition/address-book/v3/InputAddress.ts
+++ b/definition/address-book/v3/InputAddress.ts
@@ -2,7 +2,6 @@ import { Position } from "../../Position";
 
 
 type InputAddress = {
-  id?: string,
   alias?: string,
   street: string,
   additional_street?: string,

--- a/definition/address-book/v3/InputContact.ts
+++ b/definition/address-book/v3/InputContact.ts
@@ -1,5 +1,4 @@
 type InputContact = {
-  id?: string,
   company?: string,
   phone_number?: string,
   email?: string,


### PR DESCRIPTION
_Are we sure we want to give an api consumer ability to set initial address ID and change it with updates, same for contacts (in the docu InputAddress and InputContact)_

**No it's a bad construction of the document sorry, we cannot update the id**